### PR TITLE
Make plugin work with wpml 4.9.3 and above,

### DIFF
--- a/auto-anchor/auto-anchor.php
+++ b/auto-anchor/auto-anchor.php
@@ -3,7 +3,7 @@
  * Plugin Name: Auto Anchor
  * Plugin URI:  https://github.com/BenediktBergmann/WordPress-Anchor-Plugin
  * Description: Adds anchors to every header in a MS doc look.
- * Version:     1.2.5
+ * Version:     1.2.6
  * Author:      Benedikt Bergmann
  * Author URI:  https://benediktbergmann.eu
  * Text Domain: Auto-Anchor 

--- a/auto-anchor/auto-anchor.php
+++ b/auto-anchor/auto-anchor.php
@@ -76,7 +76,7 @@
 		return $content;
 
 	}
-	add_filter( 'the_content', 'AutoAnchor_add_anchors_to_headings' );
+	add_filter( 'the_content', 'AutoAnchor_add_anchors_to_headings', 99 );
 
 	function AutoAnchor_add_anchor_css_file(){
 	    wp_enqueue_style( 'anchor-style', plugins_url('/assets/style.css', __FILE__), false, '1.0.0', 'all');

--- a/auto-anchor/readme.txt
+++ b/auto-anchor/readme.txt
@@ -1,6 +1,6 @@
 === Auto Anchor ===
 Contributors: Benedikt Bergmann
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 Tags: anchor, auto, headers
 Requires at least: 5.4
 Tested up to: 6.3


### PR DESCRIPTION
The plugin causes a conflict with wpml 4.9.3 and above. Content does not show in pages that have anchor links  